### PR TITLE
Autoload operators as interactive commands

### DIFF
--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -109,7 +109,7 @@
    (if (stringp string) #'concat (lambda (x) x))
    (mapcar (lambda (c) (cdr (assoc c alist))) string)))
 
-;;;###autoload (autoload 'evil-numbers/inc-at-pt "evil-numbers")
+;;;###autoload (autoload 'evil-numbers/inc-at-pt "evil-numbers" nil t)
 (evil-define-operator evil-numbers/inc-at-pt (amount beg end type &optional incremental padded)
   "Increment the number at point or after point before end-of-line by AMOUNT.
 When region is selected, increment all numbers in the region by AMOUNT
@@ -234,7 +234,7 @@ number with a + sign.
                (funcall replace-with (lambda (x) x) (lambda (x) x))
                (error "No number at point or until end of line")))))))))
 
-;;;###autoload (autoload 'evil-numbers/dec-at-pt "evil-numbers")
+;;;###autoload (autoload 'evil-numbers/dec-at-pt "evil-numbers" nil t)
 (evil-define-operator evil-numbers/dec-at-pt (amount beg end type &optional incremental padded)
   "Decrement the number at point or after point before end-of-line by AMOUNT.
 
@@ -245,7 +245,7 @@ This function uses `evil-numbers/inc-at-pt'"
   (interactive "*<c><R>")
   (evil-numbers/inc-at-pt (- (or amount 1)) beg end type incremental padded))
 
-;;;###autoload (autoload 'evil-numbers/inc-at-pt-incremental "evil-numbers")
+;;;###autoload (autoload 'evil-numbers/inc-at-pt-incremental "evil-numbers" nil t)
 (evil-define-operator evil-numbers/inc-at-pt-incremental (amount beg end type padded)
   "Increment the number at point or after point before end-of-line by AMOUNT.
 
@@ -257,7 +257,7 @@ on."
   (interactive "*<c><R>")
   (evil-numbers/inc-at-pt amount beg end type 'incremental padded))
 
-;;;###autoload (autoload 'evil-numbers/dec-at-pt-incremental "evil-numbers")
+;;;###autoload (autoload 'evil-numbers/dec-at-pt-incremental "evil-numbers" nil t)
 (evil-define-operator evil-numbers/dec-at-pt-incremental (amount beg end type padded)
   "Like `evil-numbers/inc-at-pt-incremental' but with negated argument AMOUNT"
   :motion nil


### PR DESCRIPTION
This way the autoloaded functions are treated as interactive commands and show up in `M-x` before `evil-numbers` is loaded.