### PR TITLE
fix: handle hyphen-separated numbers correctly

### DIFF
--- a/evil-numbers.el
+++ b/evil-numbers.el
@@ -168,7 +168,9 @@ number with a + sign.
                   (replace-with
                    (lambda (from to)
                      (skip-chars-backward
-                      (funcall from "+-0123456789"))
+                      (funcall from "0123456789"))
+                     (skip-chars-backward
+                      (funcall from "+-") (- (point) 1))
                      (when (looking-at
                             (format
                              "[%s]?\\([%s]+\\)"


### PR DESCRIPTION
Imagine we're editing hyphen-separated numbers like the following:

    cursor:          v
    text:   2020-01-02

When we invoke `inc-at-pt`, we want the last number to change:

    cursor:          v
    text:   2020-01-01

(Note that the number is decremented instead of being incremented due to the leading `-`. This also matches Vim behavior)

However, evil-numbers currently change the first number instead:

    cursor:    v
    text:   2021-01-02

This patch fixes evil-numbers to match the expected behavior.